### PR TITLE
ISSUE-13 for RC3. Update Minio to use new Console.

### DIFF
--- a/deploy/ec2-docker/docker-compose-aws-s3-arm64.yml
+++ b/deploy/ec2-docker/docker-compose-aws-s3-arm64.yml
@@ -115,6 +115,7 @@ services:
       - ${ARCHIPELAGO_ROOT}/data_storage/minio-data:/data:cached
     ports:
       - "9000:9000"
+      - "9001:9001"
     networks:
       - host-net
       - esmero-net
@@ -124,7 +125,7 @@ services:
       MINIO_ROOT_PASSWORD: ${MINIO_SECRET_KEY}
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY}
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
-    command: gateway s3 https://s3.amazonaws.com/
+    command: gateway s3 https://s3.amazonaws.com/ --console-address ":9001"
 networks:
   host-net:
     driver: bridge

--- a/deploy/ec2-docker/docker-compose-aws-s3.yml
+++ b/deploy/ec2-docker/docker-compose-aws-s3.yml
@@ -115,6 +115,7 @@ services:
       - ${ARCHIPELAGO_ROOT}/data_storage/minio-data:/data:cached
     ports:
       - "9000:9000"
+      - "9001:9001"
     networks:
       - host-net
       - esmero-net
@@ -124,7 +125,7 @@ services:
       MINIO_ROOT_PASSWORD: ${MINIO_SECRET_KEY}
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY}
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
-    command: gateway s3 https://s3.amazonaws.com/
+    command: gateway s3 https://s3.amazonaws.com/ --console-address ":9001"
 networks:
   host-net:
     driver: bridge

--- a/deploy/ec2-docker/docker-compose-selfsigned.yml
+++ b/deploy/ec2-docker/docker-compose-selfsigned.yml
@@ -114,13 +114,14 @@ services:
       - ${ARCHIPELAGO_ROOT}/data_storage/minio-data:/data:cached
     ports:
       - "9000:9000"
+      - "9001:9001"
     networks:
       - host-net
       - esmero-net
     environment:
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY}
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
-    command: server /data
+    command: server /data --console-address ":9001"
 networks:
   host-net:
     driver: bridge


### PR DESCRIPTION
See #13. Tested this in combination with the AWS gateway command on a live G6 instance. Minio takes a few more seconds than usual to start but works 100%.

Note: always do a `docker-compose pull` because the new --console-address command does not work on any previous versions