### PR TITLE
ISSUE-39: Digital Ocean templates for docker-compose.yml

### DIFF
--- a/deploy/digitalocean-docker/.env.template
+++ b/deploy/digitalocean-docker/.env.template
@@ -1,0 +1,11 @@
+ARCHIPELAGO_ROOT=/home/ec2-user/archipelago-deployment-live
+ARCHIPELAGO_EMAIL=repositorysupport@metro.org
+ARCHIPELAGO_DOMAIN=newsite.archipelago.nyc
+MINIO_ACCESS_KEY=minio
+MINIO_SECRET_KEY=minio123
+MYSQL_ROOT_PASSWORD=esmero-db
+MINIO_DATACENTER_REGION=nyc3
+MINIO_BUCKET_MEDIA=esmero
+MINIO_FOLDER_PREFIX_MEDIA=media/
+MINIO_BUCKET_CACHE=esmero
+MINIO_FOLDER_PREFIX_CACHE=iiifcache/

--- a/deploy/digitalocean-docker/docker-compose-digitalocean-s3.yml
+++ b/deploy/digitalocean-docker/docker-compose-digitalocean-s3.yml
@@ -1,0 +1,134 @@
+# Run docker-compose up -d
+
+version: '3.5'
+services:
+  web:
+    container_name: esmero-web
+    image: staticfloat/nginx-certbot
+    restart: always
+    environment:
+      CERTBOT_EMAIL: ${ARCHIPELAGO_EMAIL}
+      ENVSUBST_VARS: FQDN
+      FQDN: ${ARCHIPELAGO_DOMAIN}
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ${ARCHIPELAGO_ROOT}/config_storage/nginxconfig/conf.d:/etc/nginx/user.conf.d
+      - ${ARCHIPELAGO_ROOT}/config_storage/nginxconfig/certbot_extra_domains:/etc/nginx/certbot/extra_domains:ro
+      - ${ARCHIPELAGO_ROOT}/drupal:/var/www/html:cached
+      - ${ARCHIPELAGO_ROOT}/data_storage/ngnixcache:/var/cache/nginx
+      - ${ARCHIPELAGO_ROOT}/data_storage/letsencrypt:/etc/letsencrypt
+    depends_on:
+      - solr
+      - php
+      - db
+    tty: true
+    networks:
+      - host-net
+      - esmero-net
+  php:
+    container_name: esmero-php
+    restart: always
+    image: "esmero/php-7.4-fpm:1.0.0-RC2-multiarch"
+    tty: true
+    networks:
+      - host-net
+      - esmero-net
+    volumes:
+      - ${ARCHIPELAGO_ROOT}/config_storage/php-fpm/www.conf:/usr/local/etc/php-fpm.d/www.conf
+      - ${ARCHIPELAGO_ROOT}/drupal:/var/www/html:cached
+    environment:
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MINIO_BUCKET_MEDIA: ${MINIO_BUCKET_MEDIA}
+      MINIO_FOLDER_PREFIX_MEDIA: ${MINIO_FOLDER_PREFIX_MEDIA}
+  solr:
+    container_name: esmero-solr
+    restart: always
+    image: "solr:8.8.2"
+    tty: true
+    ports:
+      - "8983:8983"
+    networks:
+      - host-net
+      - esmero-net
+    volumes:
+      - ${ARCHIPELAGO_ROOT}/data_storage/solrcore:/var/solr/data
+      - ${ARCHIPELAGO_ROOT}/config_storage/solrconfig:/drupalconfig
+      - ${ARCHIPELAGO_ROOT}/data_storage/solrlib:/opt/solr/contrib/archipelago/lib
+    entrypoint:
+      - docker-entrypoint.sh
+      - solr-precreate
+      - drupal
+      - /drupalconfig
+  db:
+    image: mysql:8.0.22
+    command: mysqld --default-authentication-plugin=mysql_native_password --binlog-expire-logs-seconds=172800 --max_allowed_packet=256M
+    container_name: esmero-db
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+    networks:
+      - host-net
+      - esmero-net
+    volumes:
+      - ${ARCHIPELAGO_ROOT}/data_storage/db:/var/lib/mysql
+  nlp:
+    container_name: esmero-nlp
+    restart: always
+    image: "esmero/esmero-nlp:1.0"
+    ports:
+      - "6400:6400"
+    networks:
+      - host-net
+      - esmero-net
+  iiif:
+    container_name: esmero-cantaloupe
+    image: "esmero/cantaloupe-s3:4.1.9RC"
+    restart: always
+    ports:
+      - "8183:8182"
+    networks:
+      - host-net
+      - esmero-net
+    environment:
+      AWS_ACCESS_KEY_ID: ${MINIO_ACCESS_KEY}
+      AWS_SECRET_ACCESS_KEY: ${MINIO_SECRET_KEY}
+      CACHE_SERVER_DERIVATIVE: S3Cache
+      S3SOURCE_BASICLOOKUPSTRATEGY_BUCKET_NAME: ${MINIO_BUCKET_MEDIA}
+      S3SOURCE_BASICLOOKUPSTRATEGY_PATH_PREFIX: ${MINIO_FOLDER_PREFIX_MEDIA}
+      S3CACHE_BUCKET_NAME: ${MINIO_BUCKET_CACHE} 
+      S3CACHE_OBJECT_KEY_PREFIX: ${MINIO_FOLDER_PREFIX_CACHE} 
+      XMS: 2g
+      XMX: 4g
+    volumes:
+      - ${ARCHIPELAGO_ROOT}/config_storage/iiifconfig:/etc/cantaloupe
+      - ${ARCHIPELAGO_ROOT}/data_storage/iiifcache:/var/cache/cantaloupe
+      - ${ARCHIPELAGO_ROOT}/data_storage/iiiftmp:/var/cache/cantaloupe_tmp
+  minio:
+    container_name: esmero-minio
+    restart: always
+    image: minio/minio:latest
+    volumes:
+      - ${ARCHIPELAGO_ROOT}/data_storage/minio-data:/data:cached
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    networks:
+      - host-net
+      - esmero-net
+    environment:
+      MINIO_HTTP_TRACE: /tmp/minio-log.txt
+      MINIO_ROOT_USER: ${MINIO_ACCESS_KEY}
+      MINIO_ROOT_PASSWORD: ${MINIO_SECRET_KEY}
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
+    command: gateway s3 https://${MINIO_DATACENTER_REGION}.digitaloceanspaces.com/ --console-address ":9001"
+networks:
+  host-net:
+    driver: bridge
+  esmero-net:
+    driver: bridge
+    internal: true

--- a/deploy/digitalocean-docker/docker-compose-digitalocean-s3.yml
+++ b/deploy/digitalocean-docker/docker-compose-digitalocean-s3.yml
@@ -64,7 +64,7 @@ services:
       - drupal
       - /drupalconfig
   db:
-    image: mysql:8.0.22
+    image: mysql:8.0.28
     command: mysqld --default-authentication-plugin=mysql_native_password --binlog-expire-logs-seconds=172800 --max_allowed_packet=256M
     container_name: esmero-db
     restart: always


### PR DESCRIPTION
Resolves #39 

The docker-compose template is identical to the AWS one except for the S3 endpoint and a new environment variable for the datacenter region, which becomes part of the endpoint url.