### PR TITLE
ISSUE-76: Make redis max memory configurable

### DIFF
--- a/deploy/ec2-docker/docker-compose-aws-s3-arm64.yml
+++ b/deploy/ec2-docker/docker-compose-aws-s3-arm64.yml
@@ -146,6 +146,8 @@ services:
       --requirepass ${REDIS_PASSWORD}
       --save 20 1
       --loglevel warning
+      --maxmemory-policy allkeys-lru
+      --maxmemory 2gb
     networks:
       - esmero-net
     volumes: 

--- a/deploy/ec2-docker/docker-compose-aws-s3.yml
+++ b/deploy/ec2-docker/docker-compose-aws-s3.yml
@@ -146,6 +146,8 @@ services:
       --requirepass ${REDIS_PASSWORD}
       --save 20 1
       --loglevel warning
+      --maxmemory-policy allkeys-lru
+      --maxmemory 2gb
     networks:
       - esmero-net
     volumes: 


### PR DESCRIPTION
Resolves part of #76.

* Added docker-compose Redis configuration option `--maxmemory 3gb`
* Added docker-compose Redis configuration option `--maxmemory-policy allkeys-lru` (least recently used)

Reference: https://redis.io/docs/manual/eviction/