### PR TITLE
ISSUE-72: Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ data_storage/solrcore/*
 drupal/composer.lock
 drupal/vendor/*
 drupal/web/*
+drupal/private/*


### PR DESCRIPTION
Continuing work for #72. Add `drupal/private/*` since we don't want anything there tracked.