### PR TITLE
ISSUE-99: Set PHP display_startup_errors to off

### DIFF
--- a/config_storage/php-fpm/www.conf
+++ b/config_storage/php-fpm/www.conf
@@ -450,3 +450,5 @@ pm.max_requests = 500
 php_admin_value[error_log] = /proc/self/fd/2
 php_admin_flag[log_errors] = on
 catch_workers_output = yes
+php_flag[display_errors] = off
+php_flag[display_startup_errors] = off

--- a/config_storage/php-fpm/www.conf
+++ b/config_storage/php-fpm/www.conf
@@ -443,7 +443,6 @@ pm.max_requests = 500
 ; Default Value: nothing is defined by default except the values in php.ini and
 ;                specified at startup with the -d argument
 ;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f www@my.domain.com
-;php_flag[display_errors] = off
 ;php_admin_value[error_log] = /var/log/fpm-php.www.log
 ;php_admin_flag[log_errors] = on
 ;php_admin_value[memory_limit] = 32M


### PR DESCRIPTION
Resolves #99 by removing commented default for `display_errors` that is no longer valid and adding overrides set to off for the same and `display_startup_errors`.