### PR TITLE
ISSUE-105: Transaction Isolation Level

### DIFF
--- a/deploy/ec2-docker/docker-compose-aws-s3-arm64.yml
+++ b/deploy/ec2-docker/docker-compose-aws-s3-arm64.yml
@@ -67,7 +67,7 @@ services:
       - /drupalconfig
   db:
     image: mariadb:10.6.8-focal
-    command: --default-authentication-plugin=mysql_native_password  --binlog-expire-logs-seconds=172800 --max_allowed_packet=256M --sort_buffer_size=512K --lower_case_table_names=1 --transaction-isolation=READ-COMMITTED
+    command: --binlog-expire-logs-seconds=172800 --max_allowed_packet=256M --sort_buffer_size=512K --lower_case_table_names=1 --transaction-isolation=READ-COMMITTED --log-bin=mysqld-bin
     container_name: esmero-db
     restart: always
     environment:

--- a/deploy/ec2-docker/docker-compose-aws-s3-arm64.yml
+++ b/deploy/ec2-docker/docker-compose-aws-s3-arm64.yml
@@ -67,7 +67,7 @@ services:
       - /drupalconfig
   db:
     image: mariadb:10.6.8-focal
-    command: --default-authentication-plugin=mysql_native_password  --binlog-expire-logs-seconds=172800 --max_allowed_packet=256M --sort_buffer_size=512K --lower_case_table_names=1
+    command: --default-authentication-plugin=mysql_native_password  --binlog-expire-logs-seconds=172800 --max_allowed_packet=256M --sort_buffer_size=512K --lower_case_table_names=1 --transaction-isolation=READ-COMMITTED
     container_name: esmero-db
     restart: always
     environment:

--- a/deploy/ec2-docker/docker-compose-aws-s3.yml
+++ b/deploy/ec2-docker/docker-compose-aws-s3.yml
@@ -67,7 +67,7 @@ services:
       - /drupalconfig
   db:
     image: mysql:8.0.28
-    command: mysqld --default-authentication-plugin=mysql_native_password --binlog-expire-logs-seconds=172800 --max_allowed_packet=256M
+    command: mysqld --default-authentication-plugin=mysql_native_password --binlog-expire-logs-seconds=172800 --max_allowed_packet=256M --transaction-isolation=READ-COMMITTED
     container_name: esmero-db
     restart: always
     environment:

--- a/deploy/ec2-docker/docker-compose-aws-s3.yml
+++ b/deploy/ec2-docker/docker-compose-aws-s3.yml
@@ -67,7 +67,7 @@ services:
       - /drupalconfig
   db:
     image: mysql:8.0.28
-    command: mysqld --default-authentication-plugin=mysql_native_password --binlog-expire-logs-seconds=172800 --max_allowed_packet=256M --transaction-isolation=READ-COMMITTED
+    command: mysqld --binlog-expire-logs-seconds=172800 --max_allowed_packet=256M --transaction-isolation=READ-COMMITTED --log-bin=mysqld-bin
     container_name: esmero-db
     restart: always
     environment:

--- a/deploy/ec2-docker/docker-compose-selfsigned.yml
+++ b/deploy/ec2-docker/docker-compose-selfsigned.yml
@@ -66,7 +66,7 @@ services:
       - /drupalconfig
   db:
     image: mysql:8.0.28
-    command: mysqld --default-authentication-plugin=mysql_native_password --binlog-expire-logs-seconds=172800 --max_allowed_packet=256M
+    command: mysqld --default-authentication-plugin=mysql_native_password --binlog-expire-logs-seconds=172800 --max_allowed_packet=256M --transaction-isolation=READ-COMMITTED
     container_name: esmero-db
     restart: always
     environment:

--- a/deploy/ec2-docker/docker-compose-selfsigned.yml
+++ b/deploy/ec2-docker/docker-compose-selfsigned.yml
@@ -66,7 +66,7 @@ services:
       - /drupalconfig
   db:
     image: mysql:8.0.28
-    command: mysqld --default-authentication-plugin=mysql_native_password --binlog-expire-logs-seconds=172800 --max_allowed_packet=256M --transaction-isolation=READ-COMMITTED
+    command: mysqld --binlog-expire-logs-seconds=172800 --max_allowed_packet=256M --transaction-isolation=READ-COMMITTED --log-bin=mysqld-bin
     container_name: esmero-db
     restart: always
     environment:


### PR DESCRIPTION
Resolves #105.

Confirmed that the esmero-db container comes up without issue for both ARM and AMD/Intel and running a mysql/mariadb query shows the right transaction isolation level.