### PR TITLE
ISSUE-125: Make maxClauseCount a larger number

### DIFF
--- a/config_storage/solrconfig/conf/solrconfig_query.xml
+++ b/config_storage/solrconfig/conf/solrconfig_query.xml
@@ -44,4 +44,4 @@
 -->
   <query name="queryResultWindowSize">20</query>
   <query name="queryResultMaxDocsCached">200</query>
-  <query name="maxBooleanClauses">1024</query>
+  <query name="maxBooleanClauses">2048</query>


### PR DESCRIPTION
See #125 
If you have too many Full Text fields and Setup a View to use any present you might see this eventually.

We have tested 4096 in production so far, keep it to what you need. 

org.apache.lucene.search.IndexSearcher$TooManyNestedClauses: Query contains too many nested clauses; maxClauseCount is set to 1024 => org.apache.lucene.search.IndexSearcher$TooManyNestedClauses: Query contains too many nested clauses; maxClauseCount is set to 1024