### PR TITLE
don't let redis save to disk

### DIFF
--- a/deploy/ec2-docker/docker-compose-aws-s3-arm64.yml
+++ b/deploy/ec2-docker/docker-compose-aws-s3-arm64.yml
@@ -169,7 +169,7 @@ services:
       - "6379:6379"
     command: >
       --requirepass ${REDIS_PASSWORD}
-      --save 20 1
+      --save ""
       --loglevel warning
       --maxmemory-policy allkeys-lru
       --maxmemory 2gb

--- a/deploy/ec2-docker/docker-compose-aws-s3.yml
+++ b/deploy/ec2-docker/docker-compose-aws-s3.yml
@@ -169,7 +169,7 @@ services:
       - "6379:6379"
     command: >
       --requirepass ${REDIS_PASSWORD}
-      --save 20 1
+      --save ""
       --loglevel warning
       --maxmemory-policy allkeys-lru
       --maxmemory 2gb


### PR DESCRIPTION
We’ve found that this line [“--save 20 1”](https://github.com/esmero/archipelago-deployment-live/blob/1.4.0/deploy/ec2-docker/docker-compose-aws-s3.yml#L172) instructs redis to save all of its data to the disk every 20 seconds. It also then makes it so it loads that data at boot. If that’s changed to `--save ""` it doesn’t save and it doesn’t load, it just exists in memory as long as the container is on (and a container restart is thus much faster). We’ve seen noticeable load decrease on servers especially around disk i/o with this setting off and I think it’s probably a better default.

The downside is that every container restart clears the Drupal cache, so perhaps folks should understand the tradeoffs in this setting.